### PR TITLE
Implement MSC-4169: backwards-compatible send of redactions for rooms < v11 using the /send endpoint

### DIFF
--- a/changelog.d/18898.feature
+++ b/changelog.d/18898.feature
@@ -1,0 +1,1 @@
+Support [MSC4169](https://github.com/matrix-org/matrix-spec-proposals/pull/4169) for backwards-compatible redaction sending using the `/send` endpoint. Contributed by @SpiritCroc @ Beeper.

--- a/synapse/config/experimental.py
+++ b/synapse/config/experimental.py
@@ -552,6 +552,9 @@ class ExperimentalConfig(Config):
         # MSC4133: Custom profile fields
         self.msc4133_enabled: bool = experimental.get("msc4133_enabled", False)
 
+        # MSC4169: Backwards-compatible redaction sending using `/send`
+        self.msc4169_enabled: bool = experimental.get("msc4169_enabled", False)
+
         # MSC4210: Remove legacy mentions
         self.msc4210_enabled: bool = experimental.get("msc4210_enabled", False)
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1017,7 +1017,7 @@ class EventCreationHandler:
                 # Legacy room versions need the "redacts" field outside of the event's
                 # content. However clients may still send it within the content, so copy
                 # the field if necessary for compatibility.
-                redacts = event_dict.get("redacts") or event_dict["content"].get(
+                redacts = event_dict.get("redacts") or event_dict["content"].pop(
                     "redacts"
                 )
                 if redacts and "redacts" not in event_dict:

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1018,7 +1018,7 @@ class EventCreationHandler:
                 # content. However clients may still send it within the content, so copy
                 # the field if necessary for compatibility.
                 redacts = event_dict.get("redacts") or event_dict["content"].pop(
-                    "redacts"
+                    "redacts", None
                 )
                 if redacts and "redacts" not in event_dict:
                     event_dict["redacts"] = redacts

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1014,7 +1014,14 @@ class EventCreationHandler:
             if room_version.updated_redaction_rules:
                 redacts = event_dict["content"].get("redacts")
             else:
-                redacts = event_dict.get("redacts")
+                # Legacy room versions need the "redacts" field outside of the event's
+                # content. However clients may still send it within the content, so copy
+                # the field if necessary for compatibility.
+                redacts = event_dict.get("redacts") or event_dict["content"].get(
+                    "redacts"
+                )
+                if redacts and "redacts" not in event_dict:
+                    event_dict["redacts"] = redacts
 
             is_admin_redaction = await self.is_admin_redaction(
                 event_type=event_dict["type"],

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1003,25 +1003,40 @@ class EventCreationHandler:
             await self.clock.sleep(random.randint(1, 10))
             raise ShadowBanError()
 
-        if ratelimit:
+        room_version = None
+
+        if (
+            event_dict["type"] == EventTypes.Redaction
+            and "redacts" in event_dict["content"]
+            and self.hs.config.experimental.msc4169_enabled
+        ):
+
             room_id = event_dict["room_id"]
             try:
                 room_version = await self.store.get_room_version(room_id)
             except NotFoundError:
-                # The room doesn't exist.
                 raise AuthError(403, f"User {requester.user} not in room {room_id}")
 
-            if room_version.updated_redaction_rules:
-                redacts = event_dict["content"].get("redacts")
-            elif self.hs.config.experimental.msc4169_enabled:
+            if not room_version.updated_redaction_rules:
                 # Legacy room versions need the "redacts" field outside of the event's
                 # content. However clients may still send it within the content, so copy
                 # the field if necessary for compatibility.
                 redacts = event_dict.get("redacts") or event_dict["content"].pop(
                     "redacts", None
                 )
-                if redacts and "redacts" not in event_dict:
+                if redacts is not None and "redacts" not in event_dict:
                     event_dict["redacts"] = redacts
+
+        if ratelimit:
+            if room_version is None:
+                room_id = event_dict["room_id"]
+                try:
+                    room_version = await self.store.get_room_version(room_id)
+                except NotFoundError:
+                    raise AuthError(403, f"User {requester.user} not in room {room_id}")
+
+            if room_version.updated_redaction_rules:
+                redacts = event_dict["content"].get("redacts")
             else:
                 redacts = event_dict.get("redacts")
 

--- a/synapse/handlers/message.py
+++ b/synapse/handlers/message.py
@@ -1013,7 +1013,7 @@ class EventCreationHandler:
 
             if room_version.updated_redaction_rules:
                 redacts = event_dict["content"].get("redacts")
-            else:
+            elif self.hs.config.experimental.msc4169_enabled:
                 # Legacy room versions need the "redacts" field outside of the event's
                 # content. However clients may still send it within the content, so copy
                 # the field if necessary for compatibility.
@@ -1022,6 +1022,8 @@ class EventCreationHandler:
                 )
                 if redacts and "redacts" not in event_dict:
                     event_dict["redacts"] = redacts
+            else:
+                redacts = event_dict.get("redacts")
 
             is_admin_redaction = await self.is_admin_redaction(
                 event_type=event_dict["type"],

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -177,7 +177,7 @@ class VersionsRestServlet(RestServlet):
                     "uk.tcpip.msc4133": self.config.experimental.msc4133_enabled,
                     # MSC4155: Invite filtering
                     "org.matrix.msc4155": self.config.experimental.msc4155_enabled,
-                    # MSC4169: Backwards-compatible redaction sending useing `/send`
+                    # MSC4169: Backwards-compatible redaction sending using `/send`
                     "com.beeper.msc4169": self.config.experimental.msc4169_enabled,
                 },
             },

--- a/synapse/rest/client/versions.py
+++ b/synapse/rest/client/versions.py
@@ -177,6 +177,8 @@ class VersionsRestServlet(RestServlet):
                     "uk.tcpip.msc4133": self.config.experimental.msc4133_enabled,
                     # MSC4155: Invite filtering
                     "org.matrix.msc4155": self.config.experimental.msc4155_enabled,
+                    # MSC4169: Backwards-compatible redaction sending useing `/send`
+                    "com.beeper.msc4169": self.config.experimental.msc4169_enabled,
                 },
             },
         )


### PR DESCRIPTION
While there is a dedicated API endpoint for redactions, being able to send redactions using the normal send endpoint is useful when using [MSC-4140](https://github.com/matrix-org/matrix-spec-proposals/pull/4140) for sending delayed redactions to replicate expiring messages. Currently this would only work on rooms >= v11 but fail with an internal server error on older room versions when setting the `redacts` field in the content, since older rooms would require that field to be outside of `content`. We can address this by copying it over if necessary.

Upstream PR: https://github.com/element-hq/synapse/pull/18898