### PR TITLE
Allow fully read markers to "go backwards"

### DIFF
--- a/synapse/handlers/read_marker.py
+++ b/synapse/handlers/read_marker.py
@@ -23,7 +23,6 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 from synapse.api.constants import ReceiptTypes
-from synapse.api.errors import SynapseError
 from synapse.types import JsonDict
 from synapse.util.async_helpers import Linearizer
 
@@ -58,25 +57,20 @@ class ReadMarkerHandler:
                 user_id, room_id, ReceiptTypes.FULLY_READ
             )
 
-            should_update = True
-            # Get event ordering, this also ensures we know about the event
-            event_ordering = await self.store.get_event_ordering(event_id, room_id)
+            # Ignore subsequent attempts to apply the same read marker.
+            if (
+                existing_read_marker is not None
+                and not isinstance(existing_read_marker.get("event_id"), str)
+                and event_id == existing_read_marker.get("event_id")
+            ):
+                return
 
-            if existing_read_marker:
-                try:
-                    old_event_ordering = await self.store.get_event_ordering(
-                        existing_read_marker["event_id"], room_id
-                    )
-                except SynapseError:
-                    # Old event no longer exists, assume new is ahead. This may
-                    # happen if the old event was removed due to retention.
-                    pass
-                else:
-                    # Only update if the new marker is ahead in the stream
-                    should_update = event_ordering > old_event_ordering
-
-            if should_update:
-                content = content = {"event_id": event_id, **(extra_content or {})}
-                await self.account_data_handler.add_account_data_to_room(
-                    user_id, room_id, ReceiptTypes.FULLY_READ, content
-                )
+            # Update the user's account data with the new read marker.
+            #
+            # Note: it's OK if this update refers to an *older* event than the
+            # previous read marker; a user may have accidentally marked some
+            # messages as read, and want to undo it.
+            content = {"event_id": event_id, **(extra_content or {})}
+            await self.account_data_handler.add_account_data_to_room(
+                user_id, room_id, ReceiptTypes.FULLY_READ, content
+            )


### PR DESCRIPTION
Cherry-picked from https://github.com/element-hq/synapse/pull/19635 .
Note there was a a small merge-conflict with 13215a73a74494eff4576eea78f1c29b83898a30 - I think I fixed it appropriately, but I didn't test that part in detail.

------

Allow `m.fully_read` markers to be updated to older events. Previously this was blocked if the update referred to an event that was older in terms of topological, then stream as a tie-breaker.

The spec does not forbid this behaviour, and a client developer would like to be able to do so to provide "undo" functionality for marking events as read.